### PR TITLE
feat: update users.getAll handler to support departmentId

### DIFF
--- a/packages/server/src/handlers/db/users/getAll.ts
+++ b/packages/server/src/handlers/db/users/getAll.ts
@@ -1,22 +1,34 @@
-import { camelCase } from 'change-case';
+import { camelCase } from "change-case";
 
-import { Handler } from '../../../types/global';
-import { User } from './models';
+import { Handler } from "../../../types/global";
+import { User } from "../../../models/user";
+
+type GetUsersOptions = {
+  // Add more fields as needed for filtering or pagination
+  departmentId: number;
+};
 
 const mapPropName = camelCase;
 
 const propNamesToLowerCase = (obj: Record<string, unknown>) =>
   Object.entries(obj).reduce(
     (obj, [key, value]) => Object.assign(obj, { [mapPropName(key)]: value }),
-    {},
+    {}
   );
 
-export const getAll: Handler<unknown, User[]> = (ctx, _input) =>
+export const getAll: Handler<GetUsersOptions, User[]> = (
+  ctx,
+  { departmentId }
+) =>
   new Promise((resolve, reject) => {
-    return ctx.globals.db.all('SELECT * FROM user', [], (err, result) => {
-      if (err) {
-        return reject(err);
+    return ctx.globals.db.all(
+      "SELECT * FROM user WHERE department_id = ?",
+      [departmentId],
+      (err, result) => {
+        if (err) {
+          return reject(err);
+        }
+        resolve(result.map(propNamesToLowerCase) as User[]);
       }
-      resolve(result.map(propNamesToLowerCase) as User[]);
-    });
+    );
   });


### PR DESCRIPTION
In order to use the newly supported departmentId in the users.getAll handler, the departmentId is now accepted as argument and passed forward as an argument to DB query.