### PR TITLE
feat: add department.countById handler

### DIFF
--- a/packages/server/src/handlers/db/departments/__tests__/countByDepartmentId.test.ts
+++ b/packages/server/src/handlers/db/departments/__tests__/countByDepartmentId.test.ts
@@ -1,0 +1,39 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { countById } from "../countByDepartmentId";
+
+describe("departments - countById", () => {
+  const mockDbGet = vi.fn();
+  const ctx = {
+    globals: {
+      db: {
+        get: mockDbGet,
+      },
+    },
+  } as any;
+
+  beforeEach(() => {
+    mockDbGet.mockReset();
+  });
+
+  it("resolves with the count when db.get succeeds", async () => {
+    mockDbGet.mockImplementation((_sql, _params, cb) => {
+      cb(null, { count: 5 });
+    });
+
+    await expect(countById(ctx, 1)).resolves.toBe(5);
+    expect(mockDbGet).toHaveBeenCalledWith(
+      "SELECT COUNT(*) as count FROM user WHERE department_id = ?",
+      [1],
+      expect.any(Function)
+    );
+  });
+
+  it("rejects with error when db.get fails", async () => {
+    const error = new Error("DB error");
+    mockDbGet.mockImplementation((_sql, _params, cb) => {
+      cb(error, undefined);
+    });
+
+    await expect(countById(ctx, 99)).rejects.toThrow("DB error");
+  });
+});

--- a/packages/server/src/handlers/db/departments/countByDepartmentId.ts
+++ b/packages/server/src/handlers/db/departments/countByDepartmentId.ts
@@ -1,0 +1,16 @@
+import { Handler } from "../../../types/global";
+
+export const countById: Handler<number, number> = (ctx, departmentId) =>
+  new Promise((resolve, reject) => {
+    const sql = "SELECT COUNT(*) as count FROM user WHERE department_id = ?";
+    ctx.globals.db.get(
+      sql,
+      [departmentId],
+      (err: any, row: { count: number }) => {
+        if (err) {
+          return reject(err);
+        }
+        resolve(row.count);
+      }
+    );
+  });

--- a/packages/server/src/handlers/index.ts
+++ b/packages/server/src/handlers/index.ts
@@ -1,12 +1,14 @@
-import { Context } from '../types/global';
-import { getById as getDepartmentById } from './db/departments/getDepartmentById';
-import { getAll as getAllUsers } from './db/users/getAll';
+import { Context } from "../types/global";
+import { getById as getDepartmentById } from "./db/departments/getDepartmentById";
+import { getAll as getAllUsers } from "./db/users/getAll";
+import { countById as countByDepartmentId } from "./db/departments/countByDepartmentId";
 
 // Add functions here to extend Context.handlers.
 export const handlerTree = {
   db: {
     department: {
       getById: getDepartmentById,
+      countById: countByDepartmentId,
     },
     user: {
       getAll: getAllUsers,
@@ -14,7 +16,7 @@ export const handlerTree = {
   },
 };
 
-export const withHandlerTree = (ctx: Omit<Context, 'handlers'>): Context => ({
+export const withHandlerTree = (ctx: Omit<Context, "handlers">): Context => ({
   ...ctx,
   handlers: handlerTree,
 });


### PR DESCRIPTION
In order to user count per department, a new handler and resolver are introduced to get the data